### PR TITLE
Add doctor unavailability management to dashboard

### DIFF
--- a/Diatrack/src/SecretaryDashboard.css
+++ b/Diatrack/src/SecretaryDashboard.css
@@ -5678,3 +5678,135 @@ textarea {
   }
 }
 
+/* Doctor Unavailable Date Styles */
+.doctor-unavailable-date {
+  background-color: #ffebee !important;
+  position: relative;
+}
+
+.doctor-unavailable-date::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  background-color: #D91341;
+  border-radius: 50%;
+}
+
+.calendar-tile-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.appointment-indicator {
+  background-color: var(--primary-blue);
+  color: white;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.unavailable-indicator {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.unavailable-marker {
+  font-size: 10px;
+}
+
+/* Doctor Availability Section in Appointments */
+.doctor-availability-section {
+  margin-top: 30px;
+  border-top: 1px solid #e0e0e0;
+  padding-top: 20px;
+}
+
+.availability-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.availability-header h3 {
+  margin: 0;
+  color: var(--dark-gray-text);
+}
+
+.unavailability-form {
+  background-color: #f8f9fa;
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.unavailable-dates-list h4 {
+  margin-bottom: 10px;
+  color: var(--dark-gray-text);
+}
+
+.unavailable-date-card {
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.unavailable-date-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.unavailable-date-card strong {
+  color: #333;
+}
+
+.unavailable-date-card .date-display {
+  margin: 5px 0;
+  color: #D91341;
+  font-weight: 500;
+}
+
+.unavailable-date-card .reason {
+  margin: 5px 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.remove-unavailable-btn {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  transition: background-color 0.2s ease;
+}
+
+.remove-unavailable-btn:hover {
+  background-color: #c82333;
+}
+
+/* Calendar tile with both appointment and unavailable */
+.dashboard-appointment-date.doctor-unavailable-date {
+  background: linear-gradient(135deg, #e3f2fd 50%, #ffebee 50%) !important;
+}


### PR DESCRIPTION
Introduces functionality for secretaries to mark doctors as unavailable on specific dates, display unavailable dates in the calendar, and prevent appointment booking on those dates. Adds UI for managing unavailable dates, including forms for adding and removing entries, and visual indicators in the calendar and appointment form. Updates styles to support new features.